### PR TITLE
[fix]confirm_success_urlの修正

### DIFF
--- a/back/config/initializers/devise_token_auth.rb
+++ b/back/config/initializers/devise_token_auth.rb
@@ -6,7 +6,7 @@ DeviseTokenAuth.setup do |config|
   # this to false to prevent the Authorization header from changing after
   # each request.
   config.change_headers_on_each_request = false
-  config.default_confirm_success_url = "http://localhost:8000/home"
+  config.default_confirm_success_url = "https://graduation-exam.vercel.app/home"
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.


### PR DESCRIPTION
## 概要
- back/config/initializers/devise_token_auth.rbのconfirm_success_urlを修正