### PR TITLE
[add]cors.rbにカンマを追記

### DIFF
--- a/back/config/initializers/cors.rb
+++ b/back/config/initializers/cors.rb
@@ -12,7 +12,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "*",
       headers: :any,
       expose: %w[access-token uid client],
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
       credentials: true
   end
 end


### PR DESCRIPTION
## 概要
- back/config/initializers/cors.rbの`head]`の後ろにカンマを追記
```Ruby
methods: [:get, :post, :put, :patch, :delete, :options, :head],
credentials: true
```