### PR TITLE
[add]wrap_parameters.rbの作成

### DIFF
--- a/back/app/api/config/initializers/wrap_parameters.rb
+++ b/back/app/api/config/initializers/wrap_parameters.rb
@@ -1,0 +1,3 @@
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters false
+end


### PR DESCRIPTION
## 概要
- back/app/api/config/initializers/wrap_parameters.rbを作成
```Ruby
ActiveSupport.on_load(:action_controller) do
  wrap_parameters false
end
```
- 下記のエラー解決のため
`Unpermitted parameter: :session. Context: { controller: DeviseTokenAuth::SessionsController, action: create, request: #<ActionDispatch::Request:0x00007f3ae8bcaa00>, params: {"email"=>"sample@sample.com", "password"=>"[FILTERED]", "controller"=>"devise_token_auth/sessions", "action"=>"create", "session"=>{"email"=>"sample@sample.com", "password"=>"[FILTERED]"}} }`
