### PR TITLE
[refactor]不要なカラム削除及びテーブル名変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 erDiagram
 Users ||--|| Profiles : has
 Users ||--o{ FavoriteCosmetics : favorites
-Users ||--|| Preferences : has
+Users ||--|| SkinInformation : has
 Users ||--o{ Cosmetics : has
 FavoriteCosmetics ||--o{ Cosmetics : has
 Users ||--o{ NotFavoriteCosmetics : has
@@ -30,8 +30,6 @@ Users {
   string email "UNIQUE"
   string provider
   string uid
-  string crypted_password
-  string salt
   string avatar
   datetime created_at
   datetime updated_at
@@ -43,68 +41,64 @@ Profiles {
   string name
   string skin_trouble
   string skin_type
-  integer age_group
+  integer age
   datetime created_at
   datetime updated_at
 }
 
 FavoriteCosmetics {
-  integer favorite_id PK
+  integer id PK
   integer user_id FK
   integer cosmetic_id FK
   datetime created_at
   datetime updated_at
 }
 
-Preferences {
-  integer preference_id PK
+SkinInformation {
+  integer id PK
   integer user_id FK
   string skin_trouble
   string skin_type
-  integer age_group
   datetime created_at
   datetime updated_at
 }
 
 Cosmetics {
-  integer cosmetic_id PK
+  integer id PK
   integer user_id FK
   string name
   string brand
-  string product_type
   string price
-  text description
-  string product_url
+  string item_url
   string image_url
   datetime created_at
   datetime updated_at
 }
 
 NotFavoriteCosmetics {
-  integer not_favorite_cosmetic_id PK
+  integer id PK
   integer user_id FK
   integer cosmetic_id FK
   text comment
-  datetime date
   datetime created_at
   datetime updated_at
 }
 
 Reviews {
-  integer review_id PK
+  integer id PK
   integer user_id FK
   integer cosmetic_id FK
   string rating
   string title
   text body
-  string product_url
+  string item_url
   string visibility
   datetime created_at
   datetime updated_at
 }
 
 Comments {
-  integer comment_id PK
+  integer id PK
   integer user_id FK
   integer review_id FK
   text body
@@ -113,7 +107,7 @@ Comments {
 }
 
 Bookmarks {
-  integer bookmark_id PK
+  integer id PK
   integer user_id FK
   integer review_id FK
   datetime created_at
@@ -121,37 +115,45 @@ Bookmarks {
 }
 
 Tags {
-  integer tag_id PK
+  integer id PK
   string tag_name
+  datetime created_at
+  datetime updated_at
 }
 
 ReviewTags {
-  integer review_id FK
+  integer id FK
   integer tag_id FK
+  datetime created_at
+  datetime updated_at
 }
 
 CosmeticUsage {
-  integer usage_id PK
+  integer id PK
   integer user_id FK
   integer cosmetic_id FK
   datetime start_date
-  datetime duration
+  datetime duration_date
   datetime open_date
   datetime expiry_date
-  integer notify_before_days
+  datetime created_at
+  datetime updated_at
 }
 
 NotificationSettings {
-  integer setting_id PK
+  integer id PK
   integer user_id FK
-  string notification_type
-  integer notify_before_days
+  integer notification_type
+  datetime created_at
+  datetime updated_at
 }
 
 Addresses {
-  integer address_id PK
+  integer id PK
   integer user_id FK
   text address
+  datetime created_at
+  datetime updated_at
 }
 ```
 
@@ -159,7 +161,7 @@ Addresses {
 韓国コスメに特化した、ユーザーのスキンケアをサポートするサービスです。
 
 具体的には、
-- 韓国コスメを使用したことがないけれど興味がある方に向けて、お悩みや肌質別に韓国コスメを提案します。
+- 韓国コスメを使用したことがないけれど興味がある方に向けて、肌質やお悩み別に韓国コスメを提案します。
 - スキンケアコスメの買い忘れ・使用期限切れを防ぐサポートをします。
 - お肌の大敵である紫外線や乾燥から、ユーザーのお肌を守るサポートをします。
 
@@ -192,16 +194,15 @@ Addresses {
 ## ■MVPリリース時に実装を予定している機能
 ## 未ログインユーザー
 ### デモ診断
-  - トップページにて、悩み・肌質・年代を選択していくと、それぞれに合った韓国コスメを提案
+  - トップページにて、肌質・お悩みを選択すると、それぞれに合った韓国コスメを提案
   - ログインせずにレコメンド機能をお試しいただき、ユーザー登録への導線をつくる
   - トップページ内に、韓国コスメを使用するメリットや人気の理由を記載
 
 ## ログインユーザー
 ### レコメンド
-- 悩み・肌質・年代などを選択したら、それぞれに合った韓国コスメを提案
+- 肌質・お悩みを選択したら、それぞれに合った韓国コスメを提案
   - 悩み…乾燥、美白、ニキビ、毛穴など
   - 肌質…脂性肌、乾燥肌、混合肌、敏感肌など
-  - 年代…10代〜60代くらいを予定
   - カテゴリごとにチェックボックスを用意して、ユーザーが選択→検索ボタンを押すと商品一覧が表示される想定
 
 - 金額を入力したら、その価格帯の韓国コスメを提案
@@ -219,12 +220,10 @@ Addresses {
   - 紫外線に注意（日傘をさしたり、日焼け止めを塗りましょう）、乾燥に注意しましょうなど
 
 ### その他
-- ユーザー登録
-- ログイン / ログアウト
-- パスワードリセット
+- Googleログイン
 - マイページ
   - プロフィール登録 / 編集 / 削除
-  - 悩み・肌質・年代の登録 / 編集 / 削除
+  - 肌質・お悩み・年代の登録 / 編集 / 削除
 
 ## ■本リリース時に実装を予定している機能
 ### レビュー投稿 / 編集 / 削除 / 一覧
@@ -239,7 +238,7 @@ Addresses {
   - ユーザーは他のユーザーの投稿にコメントできる
 
 ### タグ付け / 検索
-- 投稿に悩み・肌質・年代でタグを付けられ、ユーザーはタグで投稿を検索できる
+- 投稿に肌質・お悩み・年代でタグを付けられ、ユーザーはタグで投稿を検索できる
 
 ### お気に入りコスメ登録 / 編集 / 削除 / 一覧（マイページ内）
 - レコメンド機能でレコメンドされた韓国コスメのお気に入りと、他のユーザーのレビュー投稿のブックマークを合わせた一覧
@@ -249,10 +248,10 @@ Addresses {
 - アプリ内でレコメンドされたスキンケアコスメ以外でも記録できる
 
 ### ランキング
-- カテゴリ（悩み・肌質・年代）別にレビューの評価が高い順でランキング
+- カテゴリ（肌質・お悩み・年代）別にレビューの評価が高い順でランキング
 
 ### その他
-- レビュー投稿のX（旧Twitter）シェア
+- レコメンドされたスキンケアコスメ及びレビュー投稿のX（旧Twitter）シェア
 - テスト（RSpec）
 
 ## ■現在検討している追加サービス案

--- a/back/app/controllers/api/v1/skin_information_controller.rb
+++ b/back/app/controllers/api/v1/skin_information_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class PreferencesController < ApplicationController
+    class SkinInformationController < ApplicationController
       SKIN_TYPE_TAGS = {
         '乾燥肌' => '1001296',
         '敏感肌' => '1001297',

--- a/back/app/models/preference.rb
+++ b/back/app/models/preference.rb
@@ -1,3 +1,0 @@
-class Preference < ApplicationRecord
-  belongs_to :user
-end

--- a/back/app/models/skin_information.rb
+++ b/back/app/models/skin_information.rb
@@ -1,0 +1,3 @@
+class SkinInformation < ApplicationRecord
+  belongs_to :user
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,3 +1,3 @@
 class User < ApplicationRecord
-  has_one :preference
+  has_one :skin_information
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -2,8 +2,7 @@ Rails.application.routes.draw do
   post 'auth/:provider/callback', to: 'api/v1/users#create'
   namespace :api do
     namespace :v1 do
-      post 'preferences/search_cosmetics', to: 'preferences#search_cosmetics'
-      get 'preferences/search_cosmetics', to: 'preferences#search_cosmetics'
+      post 'skin_information/search_cosmetics', to: 'skin_information#search_cosmetics'
     end
   end
 end

--- a/back/db/migrate/20240119200329_remove_unused_column_from_users.rb
+++ b/back/db/migrate/20240119200329_remove_unused_column_from_users.rb
@@ -1,0 +1,19 @@
+class RemoveUnusedColumnFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :tokens
+    remove_column :users, :encrypted_password
+    remove_column :users, :reset_password_token
+    remove_column :users, :reset_password_sent_at
+    remove_column :users, :remember_created_at
+    remove_column :users, :sign_in_count
+    remove_column :users, :current_sign_in_at
+    remove_column :users, :last_sign_in_at
+    remove_column :users, :current_sign_in_ip
+    remove_column :users, :last_sign_in_ip
+    remove_column :users, :confirmation_token
+    remove_column :users, :confirmed_at
+    remove_column :users, :confirmation_sent_at
+    remove_column :users, :unconfirmed_email
+    remove_column :users, :allow_password_change
+  end
+end

--- a/back/db/migrate/20240119201027_rename_preferences_to_skin_information.rb
+++ b/back/db/migrate/20240119201027_rename_preferences_to_skin_information.rb
@@ -1,0 +1,5 @@
+class RenamePreferencesToSkinInformation < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :preferences, :skin_information
+  end
+end

--- a/back/db/migrate/20240119203547_remove_age_group_from_skin_information.rb
+++ b/back/db/migrate/20240119203547_remove_age_group_from_skin_information.rb
@@ -1,0 +1,5 @@
+class RemoveAgeGroupFromSkinInformation < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :skin_information, :age_group
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,18 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_16_154311) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_19_203547) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "preferences", force: :cascade do |t|
+  create_table "skin_information", force: :cascade do |t|
     t.bigint "user_id"
     t.string "skin_type", null: false
     t.string "skin_trouble", null: false
-    t.integer "age_group", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_preferences_on_user_id"
+    t.index ["user_id"], name: "index_skin_information_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -32,26 +31,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_16_154311) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
-    t.text "tokens"
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
-    t.boolean "allow_password_change", default: false
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "preferences", "users"
+  add_foreign_key "skin_information", "users"
 end

--- a/front/app/components/demo/DemonstrationResult.tsx
+++ b/front/app/components/demo/DemonstrationResult.tsx
@@ -20,7 +20,7 @@ const DemonstrationResult = () => {
   useEffect(() => {
     const fetchCosmetics = async () => {
       try {
-        const response = await axios.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/preferences/search_cosmetics`, {
+        const response = await axios.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/skin_information/search_cosmetics`, {
 					skin_type: skinType,
 					skin_trouble: skinTrouble
 				});

--- a/front/app/components/top/About.tsx
+++ b/front/app/components/top/About.tsx
@@ -9,12 +9,12 @@ const About = () => {
         何かロゴ入れたい
       </p>
       <p className="text-center justify-between p-10">
-        『アプリ名』は韓国コスメに特化した、ユーザーのスキンケアをサポートするサービスです。<br />
+        『アプリ名』は韓国コスメに特化した、毎日のスキンケアをサポートするサービスです。<br />
       </p>
       <p className="text-xl font-bold text-center justify-between pt-10">
         2つの質問に答えて</p>
       <p className="text-xl font-bold text-center justify-between pb-5">
-      ＼ あなたに合った韓国コスメを探そう ／</p>
+      あなたに合った韓国コスメを探そう</p>
       <Link href='/first_demonstration'>
         <div className="flex justify-center pb-5">
           <CustomButton colorClass="btn-506D7D">診断してみる</CustomButton>
@@ -24,7 +24,7 @@ const About = () => {
         『アプリ名』でできること
       </p>
       <ul className="text-center p-10">
-        <li>韓国コスメを使用したことがないけれど興味がある方に向けて、お悩みや肌質別に韓国コスメを提案します。</li>
+        <li>お悩みや肌質別に韓国コスメをレコメンドします。</li>
         <li>スキンケアコスメの買い忘れ・使用期限切れを防ぐサポートをします。</li>
         <li>お肌の大敵である紫外線や乾燥から、ユーザーのお肌を守るサポートをします。</li>
       </ul>


### PR DESCRIPTION
## 概要
### 不要なカラム削除及びテーブル名変更
- usersテーブルから以下のカラムを削除（devise_token_authでのログイン機能の実装中止のため）
  - tokens
  - encrypted_password
  - reset_password_token
  - reset_password_sent_at
  - remember_created_at
  - sign_in_count
  - current_sign_in_at
  - last_sign_in_at
  - current_sign_in_ip
  - last_sign_in_ip
  - confirmation_token
  - confirmed_at
  - confirmation_sent_at
  - unconfirmed_email
  - allow_password_change

- preferencesテーブルの名前をskin_informationに変更